### PR TITLE
Use new excludePaths instead of deprecated excludes_analyse

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,5 +1,5 @@
 parameters:
-    excludes_analyse:
+    excludePaths:
         - */app/code/local/*/*/data/*
         - */app/code/local/*/*/sql/*
     bootstrapFiles:


### PR DESCRIPTION
This fixes the issue on the newer phpstan:
Parameter "excludes_analyse" has been deprecated so use "excludePaths" only from now on.